### PR TITLE
Sort extensions alphabetically in error message

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -461,14 +461,15 @@ def test_free_type_font_get_mask(font: ImageFont.FreeTypeFont) -> None:
     assert mask.size == (108, 13)
 
 
-def test_load_when_image_not_found(tmp_path: Path) -> None:
-    tmpfile = tmp_path / "file.font"
-    tmpfile.write_bytes(b"")
-    tempfile = str(tmpfile)
+def test_load_when_image_not_found() -> None:
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        pass
     with pytest.raises(OSError) as e:
-        ImageFont.load(tempfile)
+        ImageFont.load(tmp.name)
 
-    root = os.path.splitext(tempfile)[0]
+    os.unlink(tmp.name)
+
+    root = os.path.splitext(tmp.name)[0]
     assert str(e.value) == f"cannot find glyph data file {root}.{{gif|pbm|png}}"
 
 
@@ -492,8 +493,8 @@ def test_load_path_existing_path() -> None:
         with pytest.raises(OSError) as e:
             ImageFont.load_path(tmp.name)
 
-        # The file exists, so the error message suggests to use `load` instead
-        assert tmp.name in str(e.value)
+    # The file exists, so the error message suggests to use `load` instead
+    assert tmp.name in str(e.value)
     assert " did you mean" in str(e.value)
 
 

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -469,7 +469,7 @@ def test_load_when_image_not_found(tmp_path: Path) -> None:
         ImageFont.load(tempfile)
 
     root = os.path.splitext(tempfile)[0]
-    assert str(e.value) == f"cannot find glyph data file {root}.{{png|gif|pbm}}"
+    assert str(e.value) == f"cannot find glyph data file {root}.{{gif|pbm|png}}"
 
 
 def test_load_path_not_found() -> None:

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -771,14 +771,13 @@ class TransposedFont:
 
 def load(filename: str) -> ImageFont:
     """
-    Load a font file.  This function loads a font object from the given
-    bitmap font file, and returns the corresponding font object.
+    Load a font file. This function loads a font object from the given
+    bitmap font file, and returns the corresponding font object. For loading TrueType
+    or OpenType fonts instead, see :py:func:`~PIL.ImageFont.truetype`.
 
     :param filename: Name of font file.
     :return: A font object.
     :exception OSError: If the file could not be read.
-
-    .. seealso:: :py:func:`PIL.ImageFont.truetype`
     """
     f = ImageFont()
     f._load_pilfont(filename)
@@ -794,7 +793,8 @@ def truetype(
 ) -> FreeTypeFont:
     """
     Load a TrueType or OpenType font from a file or file-like object,
-    and create a font object.
+    and create a font object. For loading bitmap fonts instead,
+    see :py:func:`~PIL.ImageFont.load` and :py:func:`~PIL.ImageFont.load_path`.
     This function loads a font object from the given file or file-like
     object, and creates a font object for a font of the given size.
 
@@ -855,8 +855,6 @@ def truetype(
     :return: A font object.
     :exception OSError: If the file could not be read.
     :exception ValueError: If the font size is not greater than zero.
-
-    .. seealso:: :py:func:`PIL.ImageFont.load`
     """
 
     def freetype(font: StrOrBytesPath | BinaryIO | None) -> FreeTypeFont:

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -115,7 +115,7 @@ class ImageFont:
                 if image:
                     image.close()
 
-                msg = f"cannot find glyph data file {root}.{{png|gif|pbm}}"
+                msg = f"cannot find glyph data file {root}.{{gif|pbm|png}}"
                 raise OSError(msg)
 
             self.file = fullname


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/8338

- I figured out how to use `tempfile.NamedTemporaryFile` for the other test as well
- In "cannot find glyph data file {root}.{{png|gif|pbm}}", I suggest sorting the extensions alphabetically
- You can see what the docs look like for your PR at https://pillow--8338.org.readthedocs.build/en/8338/reference/ImageFont.html#PIL.ImageFont.load.
![Screenshot 2024-09-07 at 7 54 25 PM](https://github.com/user-attachments/assets/af445a1c-d0f7-452f-b262-10484723a443)
As a user, I look at the
> See also [PIL.ImageFont.truetype()](https://pillow--8338.org.readthedocs.build/en/8338/reference/ImageFont.html#PIL.ImageFont.truetype)

and react with 'Yes, I know, I can see it right there below'. So my suggestion instead is
> For loading TrueType or OpenType fonts instead, see ``truetype()``.